### PR TITLE
refine recipe show page logic

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,6 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.3.0/css/all.css">
   </head>
 
   <body>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -10,12 +10,12 @@
   <p><i class="fa-solid fa-clock me-3"></i><%= @recipe.total_time %>m</p>
   <h3>Ingredients</h3>
   <ul>
-    <% @recipe.recipe_ingredients.each do |ingredient| %>
-    <% recipe_ingredient = Ingredient.find(ingredient.id) %>
+    <% @recipe.ingredients.each do |ingredient| %>
+    <% recipe_ingredient = RecipeIngredient.find_by(recipe: @recipe, ingredient: ingredient) %>
       <li>
-        <strong><%= truncate_zero(ingredient.quantity) %>
-        <%= recipe_ingredient.quantity_unit.downcase %></strong>
-        <%= recipe_ingredient.name.capitalize %>
+        <strong><%= truncate_zero(recipe_ingredient.quantity) %>
+        <%= ingredient.quantity_unit %></strong>
+        <%= ingredient.name %>
       </li>
     <% end %>
   </ul>


### PR DESCRIPTION
A recipe's ingredients can be shown on the page either way, through @recipe.recipe_ingredients or @recipe.ingredients. I've changed it from the former to the latter as I believe that is most correct.

(Note line 14 was incorrect anyway and should have been ingredient.ingredient_id)

As per Alessandro's message, I've also removed fontawesome from the head as it's not necessary.