### PR TITLE
reorder ingredient associations and add check to seed

### DIFF
--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -1,8 +1,9 @@
 class Ingredient < ApplicationRecord
+  has_many :recipe_ingredients
   has_many :recipes, through: :recipe_ingredients
   has_many :users, through: :user_ingredients
   has_many :user_ingredients
-  has_many :recipe_ingredients
+
 
   validates :name, presence: true
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -68,12 +68,14 @@ recipes.each do |recipe|
         quantity_unit: unit
       )
     end
+    unless db_recipe.ingredients.include?(db_ingredient) && db_ingredient.recipes.include?(db_recipe)
     RecipeIngredient.create!(
       quantity: api_ingredient[:amount],
       recipe_id: db_recipe.id,
       ingredient_id: db_ingredient.id
     )
   end
+end
 end
 end
 end


### PR DESCRIPTION
I have re-ordered the associations to fix an error when running a check to remove duplicate recipe_ingredients.

error: ActiveRecord::HasManyThroughOrderError: Cannot have a has_many :through association 'Ingredient#recipes' which goes through 'Ingredient#recipe_ingredients' before the through association is defined.

check
    unless db_recipe.ingredients.include?(db_ingredient) && db_ingredient.recipes.include?(db_recipe)
