### PR TITLE
fix(recipe/show): make new user sign-up to comment

### DIFF
--- a/app/assets/stylesheets/components/_comments.scss
+++ b/app/assets/stylesheets/components/_comments.scss
@@ -46,11 +46,6 @@
     }
   }
 
-  .text-decoration {
-    text-decoration: none;
-    color: red;
-  }
-
   textarea {
     padding: 10px;
     margin-top: 1.7rem;
@@ -61,10 +56,6 @@
     width: 100%;
     overflow-wrap: break-word;
   }
-}
-
-.gl-star-rating {
-  text-align: center;
 }
 
 .single-star {

--- a/app/assets/stylesheets/components/_comments.scss
+++ b/app/assets/stylesheets/components/_comments.scss
@@ -2,61 +2,74 @@
 
 #comment-submission {
   background-color: white;
-  padding: 1.5rem;
+  padding: 3.5rem;
   margin-bottom: 3rem;
-  width: 40vw;
+  max-width: 50vw;
   box-shadow: 3px 3px 10px rgba(209, 190, 160, 0.5);
   border-radius: 8px;
 
   h3 {
     margin-bottom: 1rem;
-    margin-left: 1rem;
   }
 
-  [type="submit"] {
+  .pink-btn {
     display: flex;
-    margin-top: 1rem;
-    margin-left: 1rem;
     padding: 4px 12px;
-    height: 2.5rem;
+    height: 2.2rem;
     border-radius: 10px;
-    border: 0;
+    border: transparent;
     background-color: $magenta;
-    letter-spacing: 1.5px;
-    font-size: 15px;
-    transition: all .3s ease;
+    transition: all 0.3s ease;
     box-shadow: #8f446b 0px 5px 0px 0px;
-    color: hsl(0, 0%, 100%);
+    text-decoration: none;
+    color: white;
+    font-size: 15px;
+    letter-spacing: 1.5px;
 
-      &:hover {
-        box-shadow: #8f446b 0px 7px 0px 0px;
-      }
+    // this applies for when it's the non-logged in button
+    a {
+      text-decoration: none;
+      color: white;
+      font-size: 15px;
+      letter-spacing: 1.5px;
+    }
 
-      &:active {
-        /*50, 168, 80*/
-        box-shadow: #8f446b 0px 0px 0px 0px;
-        transform: translateY(2px);
-        transition: 200ms;
-      }
+    &:hover {
+      box-shadow: #8f446b 0px 7px 0px 0px;
+    }
+
+    &:active {
+      /*50, 168, 80*/
+      box-shadow: #8f446b 0px 0px 0px 0px;
+      transform: translateY(2px);
+      transition: 200ms;
+    }
+  }
+
+  .text-decoration {
+    text-decoration: none;
+    color: red;
   }
 
   textarea {
     padding: 10px;
     margin-top: 1.7rem;
-    margin-left: 1rem;
-    inline-size: 32vw;
+    margin-bottom: 1rem;
+    border-radius: 4px;
+    border-color: $purple;
     height: 8rem;
+    width: 100%;
     overflow-wrap: break-word;
   }
 }
 
 .gl-star-rating {
-  margin-left: 1rem;
+  text-align: center;
 }
 
 .single-star {
-	height: 20px;
-	margin: 0 -0.11em;
+  height: 20px;
+  margin: 0 -0.11em;
 }
 
 // comments styling

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -1,5 +1,13 @@
 <%= form_with model: [recipe, review], data: { insert_comment_target: "form", action: "submit->insert-comment#send" } do |f| %>
   <%= f.select :rating, options_for_select(0..5), {}, { data: { controller: "star-rating", star_rating_target: "select" } } %>
   <%= f.text_area :content, placeholder: "Enjoy this recipe? Any questions or tips? Leave some feedback here!" %>
-  <%= f.submit "Post" %>
+  <% if user_signed_in? %>
+    <%= f.submit "Post", class: "pink-btn" %>
+  <% else %>
+    <button class="pink-btn">
+      <%= link_to new_user_registration_path do %>
+        Sign up to leave a comment!
+      <% end %>
+    </button>
+  <% end %>
 <% end %>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -20,9 +20,9 @@
               <%= f.label :dairy_free, "Dairy-free" %>
             </div>
           </div>
-          <% if current_user == nil %>
+          <% if current_user.nil? %>
             <p class="not-loggedin-text">You can add your kitchen staples to the pantry and include them here!</p>
-            <%= link_to profile_ingredients_path, id: "btn-ingredients" do %>
+            <%= link_to new_user_registration_path, id: "btn-ingredients" do %>
               Add to pantry<i class="fa-solid fa-plus"></i>
             <% end %>
           <% end %>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -23,7 +23,7 @@
             <% end %>
           <% end %>
         <% end %>
-        <% if user_signed_in? == false %>
+        <% if !user_signed_in? %>
           <%= link_to new_user_registration_path do %>
             <i class="fa-regular fa-bookmark" ></i>
           <% end %>


### PR DESCRIPTION
### Main changes

- Create sign-up button for when a non-logged in user tries to submit a comment or rating on a recipe; it will direct them to the sign-up page. If the user is logged in, the button will say 'Post'; if the user is not, the button will say 'Sign up to leave a comment!'.
- Make user unable to add ingredients to pantry unless they are signed up, by re-directing them to the sign-in page.

### Minor changes

- Implement some relatively minor CSS changes to the 'Add a Comment/Rating' section ~that didn't want to make me pull my hair out~. (Am aware of the repetitive code depending on the button for `pink.btn` so will refactor).
- Small refactoring of checking `user_signed_in?` value.